### PR TITLE
support boost 1.65 flat_map & flat_set

### DIFF
--- a/VS2012/Visualizers/boost_Containers.natvis
+++ b/VS2012/Visualizers/boost_Containers.natvis
@@ -163,10 +163,19 @@
     </Expand>
 </Type>
 
+<!-- boost < 1.65 -->
 <Type Name="boost::container::flat_map&lt;*&gt;">
     <DisplayString>{m_flat_tree.m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_flat_tree.m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_map&lt;*&gt;">
+    <DisplayString>{m_flat_tree.m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_flat_tree.m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 
@@ -178,10 +187,27 @@
     </Expand>
 </Type>
 
+<!-- boost < 1.58 -->
 <Type Name="boost::container::flat_set&lt;*&gt;">
     <DisplayString>{m_flat_tree.m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_flat_tree.m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.58 -->
+<Type Name="boost::container::flat_set&lt;*&gt;">
+    <DisplayString>{m_data.m_vect}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_set&lt;*&gt;">
+    <DisplayString>{m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 

--- a/VS2013/Visualizers/boost_Containers.natvis
+++ b/VS2013/Visualizers/boost_Containers.natvis
@@ -183,10 +183,19 @@
     </Expand>
 </Type>
 
+<!-- boost < 1.65 -->
 <Type Name="boost::container::flat_map&lt;*&gt;">
     <DisplayString>{m_flat_tree.m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_flat_tree.m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_map&lt;*&gt;">
+    <DisplayString>{m_flat_tree.m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_flat_tree.m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 
@@ -212,6 +221,14 @@
     <DisplayString>{m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_set&lt;*&gt;">
+    <DisplayString>{m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 

--- a/VS2015/Visualizers/boost_Containers.natvis
+++ b/VS2015/Visualizers/boost_Containers.natvis
@@ -255,10 +255,19 @@
     </Expand>
 </Type>
 
-<Type Name="boost::container::flat_map&lt;*&gt;">
+<!-- boost < 1.65 -->
+<Type Name="boost::container::flat_map&lt;*&gt;" Priority="MediumLow">
     <DisplayString>{m_flat_tree.m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_flat_tree.m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_map&lt;*&gt;" Priority="Medium">
+    <DisplayString>{m_flat_tree.m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_flat_tree.m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 
@@ -284,6 +293,14 @@
     <DisplayString>{m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_set&lt;*&gt;" Priority="MediumHigh">
+    <DisplayString>{m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 

--- a/VS2017/Visualizers/boost_Containers.natvis
+++ b/VS2017/Visualizers/boost_Containers.natvis
@@ -262,10 +262,19 @@
     </Expand>
 </Type>
 
-<Type Name="boost::container::flat_map&lt;*&gt;">
+<!-- boost < 1.65 -->
+<Type Name="boost::container::flat_map&lt;*&gt;" Priority="MediumLow">
     <DisplayString>{m_flat_tree.m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_flat_tree.m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_map&lt;*&gt;" Priority="Medium">
+    <DisplayString>{m_flat_tree.m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_flat_tree.m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 
@@ -295,6 +304,14 @@
     <DisplayString>{m_data.m_vect}</DisplayString>
     <Expand>
         <ExpandedItem>m_data.m_vect</ExpandedItem>
+    </Expand>
+</Type>
+
+<!-- boost >= 1.65 -->
+<Type Name="boost::container::flat_set&lt;*&gt;" Priority="MediumHigh">
+    <DisplayString>{m_data.m_seq}</DisplayString>
+    <Expand>
+        <ExpandedItem>m_data.m_seq</ExpandedItem>
     </Expand>
 </Type>
 


### PR DESCRIPTION
Internal member got renamed from m_vect to m_seq in this boost commit:

  https://github.com/boostorg/container/commit/d6749960fc896c451cb23633f1f6f3144cdf4017

Add support for that change to visualizers for all VS versions.
While merging to VS2012, I've merged there also the support for
boost::flat_set 1.58 from the newer ones.
 
I've amended the commit to remove the Priority attribute for VS < 2015, where it's not supported.
Tested now with VS2017,2015,2013, but not 2012 which I don't have at hand.