### PR TITLE
Add simple icu visualizer.

### DIFF
--- a/VS2017/Visualizers/icu.natvis
+++ b/VS2017/Visualizers/icu.natvis
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
 
-    <Type Name="icu_61::UnicodeString">
+    <Type Name="icu::UnicodeString">
+        <AlternativeType Name="icu_58::UnicodeString" />
+        <AlternativeType Name="icu_59::UnicodeString" />
+        <AlternativeType Name="icu_60::UnicodeString" />
+        <AlternativeType Name="icu_61::UnicodeString" />
+        <AlternativeType Name="icu_62::UnicodeString" />
+        <AlternativeType Name="icu_63::UnicodeString" />
+
         <!-- small (stack) string -->
         <DisplayString Condition="fUnion.fFields.fLengthAndFlags &amp; kUsingStackBuffer">
             {fUnion.fStackFields.fBuffer,[fUnion.fFields.fLengthAndFlags >> kLengthShift]na}

--- a/VS2017/Visualizers/icu.natvis
+++ b/VS2017/Visualizers/icu.natvis
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+    <Type Name="icu_61::UnicodeString">
+        <!-- small (stack) string -->
+        <DisplayString Condition="fUnion.fFields.fLengthAndFlags &amp; kUsingStackBuffer">
+            {fUnion.fStackFields.fBuffer,[fUnion.fFields.fLengthAndFlags >> kLengthShift]na}
+        </DisplayString>
+
+        <!-- large string, small length -->
+        <DisplayString Condition="fUnion.fFields.fLengthAndFlags > 0">
+            {fUnion.fFields.fArray,[fUnion.fFields.fLengthAndFlags >> kLengthShift]na}
+        </DisplayString>
+
+        <!-- large string -->
+        <DisplayString Condition="fUnion.fFields.fLengthAndFlags &amp; kLengthIsLarge">
+            {fUnion.fFields.fArray,[fUnion.fFields.fLength]na}
+        </DisplayString>
+
+
+        <!-- small (stack) string -->
+        <StringView Condition="fUnion.fFields.fLengthAndFlags &amp; kUsingStackBuffer">
+            fUnion.fStackFields.fBuffer,[fUnion.fFields.fLengthAndFlags >> kLengthShift]na
+        </StringView>
+
+        <!-- large string, small length -->
+        <StringView Condition="fUnion.fFields.fLengthAndFlags > 0">
+            fUnion.fFields.fArray,[fUnion.fFields.fLengthAndFlags >> kLengthShift]na
+        </StringView>
+
+        <!-- large string -->
+        <StringView Condition="fUnion.fFields.fLengthAndFlags &amp; kLengthIsLarge">
+            fUnion.fFields.fArray,[fUnion.fFields.fLength]na
+        </StringView>
+    </Type>
+
+</AutoVisualizer>


### PR DESCRIPTION
One drawback is that icu has options about its namespace.
Sometimes it could be `icu`, sometimes `icu_Version` (e.g. `icu_61`).