### PR TITLE
fix boost container vector

### DIFF
--- a/VS2017/Visualizers/boost_Containers.natvis
+++ b/VS2017/Visualizers/boost_Containers.natvis
@@ -365,6 +365,19 @@
     </Expand>
 </Type>
 
+<!-- boost 1.67 >= -->
+<Type Name="boost::container::vector_alloc_holder&lt;*,*,*&gt;">
+    <DisplayString>{{ size={m_size} }}</DisplayString>
+    <Expand>
+        <Item Name="[size]" ExcludeView="simple">m_size</Item>
+        <Item Name="[capacity]" ExcludeView="simple">m_capacity</Item>
+        <ArrayItems>
+            <Size>m_size</Size>
+            <ValuePointer>m_start</ValuePointer>
+        </ArrayItems>
+    </Expand>
+</Type>
+
 <!-- boost 1.55 >= -->
 <Type Name="boost::container::vector&lt;*,*&gt;">
     <DisplayString>{m_holder}</DisplayString>

--- a/VS2017/Visualizers/boost_DateTime.natvis
+++ b/VS2017/Visualizers/boost_DateTime.natvis
@@ -41,14 +41,14 @@
 
 <!--boost::posix_time::time_duration-->
 <Type Name="boost::date_time::time_duration&lt;boost::posix_time::time_duration,boost::date_time::time_resolution_traits&lt;boost::date_time::time_resolution_traits_adapted64_impl,*,*&gt; &gt;">
-    <Intrinsic Name="day"         Expression="ticks_.value_/(86400*$T2)"/>
-    <Intrinsic Name="_t_hours"    Expression="ticks_.value_-(86400*$T2)*day()"/>
-    <Intrinsic Name="hour"        Expression="_t_hours()/(3600*$T2)"/>
-    <Intrinsic Name="_t_minutes"  Expression="_t_hours()-(3600*$T2)*hour()"/>
-    <Intrinsic Name="minute"      Expression="_t_minutes()/(60*$T2)"/>
-    <Intrinsic Name="second"      Expression="(_t_minutes()-(60*$T2)*minute())/$T2"/>
-    <Intrinsic Name="millisecond" Expression="(ticks_.value_%$T2)/1000"/>
-    <Intrinsic Name="nanosecond"  Expression="ticks_.value_%1000"/>
+    <Intrinsic Name="day"         Expression="ticks_.value_/(86400ll*$T2)"/>
+    <Intrinsic Name="_t_hours"    Expression="ticks_.value_-(86400ll*$T2)*day()"/>
+    <Intrinsic Name="hour"        Expression="_t_hours()/(3600ll*$T2)"/>
+    <Intrinsic Name="_t_minutes"  Expression="_t_hours()-(3600ll*$T2)*hour()"/>
+    <Intrinsic Name="minute"      Expression="_t_minutes()/(60ll*$T2)"/>
+    <Intrinsic Name="second"      Expression="(_t_minutes()-(60ll*$T2)*minute())/$T2"/>
+    <Intrinsic Name="millisecond" Expression="(ticks_.value_%$T2)/1000ll"/>
+    <Intrinsic Name="nanosecond"  Expression="ticks_.value_%1000ll"/>
     <DisplayString>{day()}d {hour()/10}{hour()%10}:{minute()/10}{minute()%10}:{second()/10}{second()%10} {millisecond()}ms {nanosecond()}us</DisplayString>
     <Expand>
         <Synthetic Name="[day]"><DisplayString>{day()}</DisplayString></Synthetic>


### PR DESCRIPTION
At some point the namespace and number of template arguments for boost::container::vector_alloc_holder changed. This caused the visualizers for the flat containers to display incorrectly. This fixes it for me.