### PR TITLE
A fix for issue #39

### DIFF
--- a/VS2017/Visualizers/boost_MultiIndex.natvis
+++ b/VS2017/Visualizers/boost_MultiIndex.natvis
@@ -54,39 +54,38 @@
     </Expand>
   </Type>
 
-  <Type Name="boost::multi_index::detail::header_holder&lt;boost::multi_index::detail::hashed_index_node&lt;*,*&gt;*,*&gt;">
-    <DisplayString>{{ size={(($T3*)this)-&gt;node_count} }}</DisplayString>
+  <Type Name="boost::multi_index::detail::header_holder&lt;boost::multi_index::detail::hashed_index_node&lt;*&gt;*,*&gt;">
+    <DisplayString>{{ size={ (($T2*)this)-&gt;node_count } ende  }}</DisplayString>
     <Expand>
       <!--Easier to take size from auto_space<...> since it always +1 from real size-->
-      <Item Name="[buckets]" IncludeView="detailed">(($T3*)this)-&gt;buckets.spc.n_ - 1</Item>
-      <Item Name="[max_load]" IncludeView="detailed">(($T3*)this)-&gt;max_load</Item>
-      <Item Name="[max_load_factor]" IncludeView="detailed">(($T3*)this)-&gt;mlf</Item>
-      <Item Name="[key_eq]" IncludeView="detailed">(($T3*)this)-&gt;eq_</Item>
-      <Item Name="[hash_function]" IncludeView="detailed">(($T3*)this)-&gt;hash_</Item>
+      <Item Name="[buckets]" IncludeView="detailed">(($T2*)this)-&gt;buckets.spc.n_ - 1</Item>
+      <Item Name="[max_load]" IncludeView="detailed">(($T2*)this)-&gt;max_load</Item>
+      <Item Name="[max_load_factor]" IncludeView="detailed">(($T2*)this)-&gt;mlf</Item>
+      <Item Name="[key_eq]" IncludeView="detailed">(($T2*)this)-&gt;eq_</Item>
+      <Item Name="[hash_function]" IncludeView="detailed">(($T2*)this)-&gt;hash_</Item>
       <CustomListItems>
-        <Variable Name="NumBuckets" InitialValue="(($T3*)this)-&gt;buckets.spc.n_ - 1"/>
-        <Variable Name="BucketIndex" InitialValue="0"/>
-        <Variable Name="NodePtr" InitialValue="(boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)nullptr"/>
-
-        <!-- Iterate through all buckets -->
-        <Loop>
-          <Break Condition="BucketIndex == NumBuckets"/>
-
-          <!-- If bucket is not empty -->
-          <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)((((($T3*)this)-&gt;buckets.spc.data_ + BucketIndex))-&gt;prior_)</Exec>
-          <If Condition="NodePtr != nullptr">
-            <!-- Let's iterate over its nodes -->
-            <Loop>
-              <Item>*reinterpret_cast&lt;$T3::value_type*&gt;(&amp;(((boost::multi_index::detail::hashed_index_node&lt;$T1,$T2&gt;*)NodePtr))-&gt;space)</Item>
-
-              <!-- Tricky (but legal) check that node is last -->
-              <Break Condition="NodePtr-&gt;next_-&gt;prior_ != NodePtr"/>
-              <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)(NodePtr-&gt;next_)</Exec>
-            </Loop>
-          </If>
-
-          <Exec>++BucketIndex</Exec>
-        </Loop>
+	<Variable Name="NumBuckets" InitialValue="(($T2*)this)-&gt;buckets.spc.n_ - 1"/>
+	<Variable Name="BucketIndex" InitialValue="0"/>
+	<Variable Name="NodePtr" InitialValue="(boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)nullptr"/>
+	
+	<!--Iterate through all buckets--> 
+	<Loop>
+	  <Break Condition="BucketIndex == NumBuckets"/>
+	  
+	  <!--If bucket is not empty--> 
+	  <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)((((($T2*)this)-&gt;buckets.spc.data_ + BucketIndex))-&gt;prior_)</Exec>
+	  <If Condition="NodePtr != nullptr">
+	    <!--Let's iterate over its nodes--> 
+	    <Loop>
+	      <Item>*reinterpret_cast&lt;$T2::value_type*&gt;(&amp;(((boost::multi_index::detail::hashed_index_node&lt;$T1&gt;*)NodePtr))-&gt;space)</Item>
+	      <!--Tricky (but legal) check that node is last-->
+	      <Break Condition="NodePtr-&gt;next_-&gt;prior_ != NodePtr"/>
+	      <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)(NodePtr-&gt;next_)</Exec>
+	    </Loop>
+	  </If>
+	  
+	  <Exec>++BucketIndex</Exec>
+	</Loop>
       </CustomListItems>
     </Expand>
   </Type>

--- a/VS2017/Visualizers/boost_MultiIndex.natvis
+++ b/VS2017/Visualizers/boost_MultiIndex.natvis
@@ -55,7 +55,7 @@
   </Type>
 
   <Type Name="boost::multi_index::detail::header_holder&lt;boost::multi_index::detail::hashed_index_node&lt;*&gt;*,*&gt;">
-    <DisplayString>{{ size={ (($T2*)this)-&gt;node_count } ende  }}</DisplayString>
+    <DisplayString>{{ size={ (($T2*)this)-&gt;node_count } }}</DisplayString>
     <Expand>
       <!--Easier to take size from auto_space<...> since it always +1 from real size-->
       <Item Name="[buckets]" IncludeView="detailed">(($T2*)this)-&gt;buckets.spc.n_ - 1</Item>

--- a/VS2019/Visualizers/boost_MultiIndex.natvis
+++ b/VS2019/Visualizers/boost_MultiIndex.natvis
@@ -54,41 +54,39 @@
     </Expand>
   </Type>
 
-  <Type Name="boost::multi_index::detail::header_holder&lt;boost::multi_index::detail::hashed_index_node&lt;*,*&gt;*,*&gt;">
-    <DisplayString>{{ size={(($T3*)this)-&gt;node_count} }}</DisplayString>
+  <Type Name="boost::multi_index::detail::header_holder&lt;boost::multi_index::detail::hashed_index_node&lt;*&gt;*,*&gt;">
+    <DisplayString>{{ size={ (($T2*)this)-&gt;node_count } ende  }}</DisplayString>
     <Expand>
       <!--Easier to take size from auto_space<...> since it always +1 from real size-->
-      <Item Name="[buckets]" IncludeView="detailed">(($T3*)this)-&gt;buckets.spc.n_ - 1</Item>
-      <Item Name="[max_load]" IncludeView="detailed">(($T3*)this)-&gt;max_load</Item>
-      <Item Name="[max_load_factor]" IncludeView="detailed">(($T3*)this)-&gt;mlf</Item>
-      <Item Name="[key_eq]" IncludeView="detailed">(($T3*)this)-&gt;eq_</Item>
-      <Item Name="[hash_function]" IncludeView="detailed">(($T3*)this)-&gt;hash_</Item>
+      <Item Name="[buckets]" IncludeView="detailed">(($T2*)this)-&gt;buckets.spc.n_ - 1</Item>
+      <Item Name="[max_load]" IncludeView="detailed">(($T2*)this)-&gt;max_load</Item>
+      <Item Name="[max_load_factor]" IncludeView="detailed">(($T2*)this)-&gt;mlf</Item>
+      <Item Name="[key_eq]" IncludeView="detailed">(($T2*)this)-&gt;eq_</Item>
+      <Item Name="[hash_function]" IncludeView="detailed">(($T2*)this)-&gt;hash_</Item>
       <CustomListItems>
-        <Variable Name="NumBuckets" InitialValue="(($T3*)this)-&gt;buckets.spc.n_ - 1"/>
-        <Variable Name="BucketIndex" InitialValue="0"/>
-        <Variable Name="NodePtr" InitialValue="(boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)nullptr"/>
-
-        <!-- Iterate through all buckets -->
-        <Loop>
-          <Break Condition="BucketIndex == NumBuckets"/>
-
-          <!-- If bucket is not empty -->
-          <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)((((($T3*)this)-&gt;buckets.spc.data_ + BucketIndex))-&gt;prior_)</Exec>
-          <If Condition="NodePtr != nullptr">
-            <!-- Let's iterate over its nodes -->
-            <Loop>
-              <Item>*reinterpret_cast&lt;$T3::value_type*&gt;(&amp;(((boost::multi_index::detail::hashed_index_node&lt;$T1,$T2&gt;*)NodePtr))-&gt;space)</Item>
-
-              <!-- Tricky (but legal) check that node is last -->
-              <Break Condition="NodePtr-&gt;next_-&gt;prior_ != NodePtr"/>
-              <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)(NodePtr-&gt;next_)</Exec>
-            </Loop>
-          </If>
-
-          <Exec>++BucketIndex</Exec>
-        </Loop>
+	<Variable Name="NumBuckets" InitialValue="(($T2*)this)-&gt;buckets.spc.n_ - 1"/>
+	<Variable Name="BucketIndex" InitialValue="0"/>
+	<Variable Name="NodePtr" InitialValue="(boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)nullptr"/>
+	
+	<!--Iterate through all buckets--> 
+	<Loop>
+	  <Break Condition="BucketIndex == NumBuckets"/>
+	  
+	  <!--If bucket is not empty--> 
+	  <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)((((($T2*)this)-&gt;buckets.spc.data_ + BucketIndex))-&gt;prior_)</Exec>
+	  <If Condition="NodePtr != nullptr">
+	    <!--Let's iterate over its nodes--> 
+	    <Loop>
+	      <Item>*reinterpret_cast&lt;$T2::value_type*&gt;(&amp;(((boost::multi_index::detail::hashed_index_node&lt;$T1&gt;*)NodePtr))-&gt;space)</Item>
+	      <!--Tricky (but legal) check that node is last-->
+	      <Break Condition="NodePtr-&gt;next_-&gt;prior_ != NodePtr"/>
+	      <Exec>NodePtr = (boost::multi_index::detail::hashed_index_node_trampoline&lt;$T1&gt;*)(NodePtr-&gt;next_)</Exec>
+	    </Loop>
+	  </If>
+	  
+	  <Exec>++BucketIndex</Exec>
+	</Loop>
       </CustomListItems>
     </Expand>
   </Type>
-
 </AutoVisualizer>

--- a/VS2019/Visualizers/boost_MultiIndex.natvis
+++ b/VS2019/Visualizers/boost_MultiIndex.natvis
@@ -55,7 +55,7 @@
   </Type>
 
   <Type Name="boost::multi_index::detail::header_holder&lt;boost::multi_index::detail::hashed_index_node&lt;*&gt;*,*&gt;">
-    <DisplayString>{{ size={ (($T2*)this)-&gt;node_count } ende  }}</DisplayString>
+    <DisplayString>{{ size={ (($T2*)this)-&gt;node_count } }}</DisplayString>
     <Expand>
       <!--Easier to take size from auto_space<...> since it always +1 from real size-->
       <Item Name="[buckets]" IncludeView="detailed">(($T2*)this)-&gt;buckets.spc.n_ - 1</Item>


### PR DESCRIPTION
It seems so that the type
**boost::multi_index::detail::header_holder<boost::multi_index::detail::hashed_index_node<..**. changed in the past or the visualizer for this type never worked. With my fix  the debugger shows all items contained in the the collection.